### PR TITLE
Fix setting WebhookOptions.

### DIFF
--- a/Comet/AdminMetaWebhookOptionsSetRequest.php
+++ b/Comet/AdminMetaWebhookOptionsSetRequest.php
@@ -58,7 +58,9 @@ class AdminMetaWebhookOptionsSetRequest implements \Comet\NetworkRequest {
 	public function Parameters()
 	{
 		$ret = [];
-		$ret["WebhookOptions"] = (string)($this->WebhookOptions);
+		$ret["WebhookOptions"] = json_encode(array_map(function ($webhookOption) {
+            return $webhookOption->toArray();
+        }, $this->WebhookOptions));
 		return $ret;
 	}
 	


### PR DESCRIPTION
Using AdminMetaWebhookOptionsSetRequest doesn't work without this fix.

$webhookOption = WebhookOption::createFromArray([
            'URL' => 'https://935056aaf0dd.ngrok.io/webhooks/cometbackup',
            'WhiteListedEventTypes' => [4102],
        ]);

        return $this->server->AdminMetaWebhookOptionsSet(['this is a not useful key' => $webhookOption]);